### PR TITLE
added lean benchmarks

### DIFF
--- a/capn/Cargo.lock
+++ b/capn/Cargo.lock
@@ -7,14 +7,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "capn"
 version = "0.1.0"
 dependencies = [
- "capnp 0.9.0",
- "capnpc 0.9.0",
+ "capnp 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "capnpc 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "memmap 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "capnp"
 version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byteorder 1.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -22,8 +23,9 @@ dependencies = [
 [[package]]
 name = "capnpc"
 version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "capnp 0.9.0",
+ "capnp 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -61,6 +63,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [metadata]
 "checksum byteorder 1.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "90492c5858dd7d2e78691cfb89f90d273a2800fc11d98f60786e5d87e2f83781"
+"checksum capnp 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b3cfa57795aeab467713586aa427c82c9ea0bf917c641c95cd7966f0681ecd80"
+"checksum capnpc 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6f85b818d7d9d63ca794b96b00ff28e2c44cfeeec6adb44fa4b4de8e05eb4e75"
 "checksum libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)" = "76e3a3ef172f1a0b9a9ff0dd1491ae5e6c948b94479a3021819ba7d860c8645d"
 "checksum memmap 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6585fd95e7bb50d6cc31e20d4cf9afb4e2ba16c5846fc76793f11218da9c475b"
 "checksum winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "92c1eb33641e276cfa214a0522acad57be5c56b10cb348b3c5117db75f3ac4b0"

--- a/capn/Cargo.toml
+++ b/capn/Cargo.toml
@@ -6,16 +6,16 @@ build = "build.rs"
 
 
 [dependencies]
-#capnp = "0.9"
+capnp = "0.9"
 memmap = "0.7.0"
 
 [build-dependencies]
-#capnpc = "0.9"
+capnpc = "0.9"
 
-[dependencies.capnp]
-path = "/usr/src/capnproto-rust/capnp"
-[build-dependencies.capnpc]
-path = "/usr/src/capnproto-rust/capnpc"
+#[dependencies.capnp]
+#path = "/usr/src/capnproto-rust/capnp"
+#[build-dependencies.capnpc]
+#path = "/usr/src/capnproto-rust/capnpc"
 
 
 [profile.release]


### PR DESCRIPTION
This PR adds lean benchmark variants for abomonation and capnproto. These benchmarks encode starting from a `&Vec<String>` and populating a correctly sized empty `&mut Vec<u8>`. They decode starting from a pre-populated `&mut [u8]`. 

On my laptop, I see the following numbers (note: the non-lean ones that assume a file exists just fail).

For abomonation:

```
running 6 tests
test tests::bench_decode_10000th      ... FAILED
test tests::bench_decode_10000th_lean ... bench:   5,852,668 ns/iter (+/- 302,954)
test tests::bench_decode_all          ... FAILED
test tests::bench_decode_all_lean     ... bench:  32,975,832 ns/iter (+/- 3,306,251)
test tests::bench_encode              ... bench: 437,243,851 ns/iter (+/- 155,641,424)
test tests::bench_encode_lean         ... bench:  29,675,535 ns/iter (+/- 19,320,665)
```

for capnproto:

```
running 6 tests
test tests::bench_decode_10000th      ... FAILED
test tests::bench_decode_10000th_lean ... bench:         284 ns/iter (+/- 162)
test tests::bench_decode_all          ... FAILED
test tests::bench_decode_all_lean     ... bench: 272,806,456 ns/iter (+/- 28,849,189)
test tests::bench_encode              ... bench: 465,073,712 ns/iter (+/- 10,418,753)
test tests::bench_encode_lean         ... bench: 130,640,751 ns/iter (+/- 6,132,685)
```

I think these demonstrate a bit better the intended trade-offs: capnproto is very fast at random access, but (at least in these measurements) much less good at bulk serialization and deserialization.

Note: I did change `Cargo.toml` to be something that avoids local dependencies. It sounds like the allocation in the error case is something the capnproto folks can look into (hooray for having solid baselines; we all get better as a result).